### PR TITLE
CI on both lts and latest composer version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
                 php_version:
                     - 8.3
                     - 8.4
+                composer_version:
+                    - lts
+                    - latest
                 composer_extra_args:
                     - '--prefer-lowest'
                     - '--prefer-stable'
@@ -22,7 +25,7 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: "Build container"
-              run: DOCKER_UID=${UID} PHP_VERSION=${{ matrix.php_version }} docker compose build
+              run: DOCKER_UID=${UID} PHP_VERSION=${{ matrix.php_version }} COMPOSER_VERSION=${{ matrix.composer_version }} docker compose build
 
             - name: "Start container"
               run: DOCKER_UID=${UID} docker compose run --detach --name php-container php sleep infinity

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 ARG PHP_VERSION="8"
+ARG COMPOSER_VERSION="lts"
+FROM composer:${COMPOSER_VERSION} AS composer_stage
 FROM php:${PHP_VERSION}-cli-alpine
 RUN apk add --update --no-cache \
     bash
-COPY --from=composer:lts /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer_stage /usr/bin/composer /usr/local/bin/composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG PHP_VERSION="8"
 ARG COMPOSER_VERSION="lts"
 FROM composer:${COMPOSER_VERSION} AS composer_stage
 FROM php:${PHP_VERSION}-cli-alpine
+ENV COMPOSER_ROOT_VERSION=dev-main
 RUN apk add --update --no-cache \
     bash
 COPY --from=composer_stage /usr/bin/composer /usr/local/bin/composer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,4 @@ services:
         context: .
         args:
           PHP_VERSION: ${PHP_VERSION:-8}
+          COMPOSER_VERSION: ${COMPOSER_VERSION:-lts}


### PR DESCRIPTION
Run our CI workflow on both `composer:lts` and `composer:latest`. This ensures that we catch any errors on newer versions on composer