### PR TITLE
x: Added phpstan rules to verify access between layers in hexagonal arch…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,4 @@
 {
-    "version": "1.0.1",
     "name": "hiperdk/phpstan-rules",
     "description": "PHPStan rules by Hiper",
     "type": "phpstan-extension",

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "version": "1.0.1",
     "name": "hiperdk/phpstan-rules",
     "description": "PHPStan rules by Hiper",
     "type": "phpstan-extension",
@@ -11,6 +12,10 @@
         {
             "name": "Frederik Hørgreen",
             "homepage": "https://github.com/frederikhs"
+        },
+        {
+            "name": "Kim Winther Carlsen",
+            "homepage": "https://github.com/krchiper"
         }
     ],
     "config": {
@@ -39,6 +44,11 @@
     "autoload": {
         "psr-4": {
             "Hiper\\PHPStan\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Test\\": "tests/test-fixtures"
         }
     },
     "scripts": {

--- a/extension.neon
+++ b/extension.neon
@@ -3,3 +3,7 @@ services:
     class: Hiper\PHPStan\Rules\TypedConstantRule
     tags:
       - phpstan.rules.rule
+  -
+    class: Hiper\PHPStan\Rules\DomainDrivenDesignRule
+    tags:
+      - phpstan.rules.rule

--- a/src/Rules/DomainDrivenDesignRule.php
+++ b/src/Rules/DomainDrivenDesignRule.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Hiper\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<FullyQualified>
+ */
+class DomainDrivenDesignRule implements Rule {
+    #[\Override]
+    public function getNodeType(): string {
+        return FullyQualified::class;
+    }
+
+    #[\Override]
+    public function processNode(Node $node, Scope $scope): array {
+        $currentFile = $scope->getFile();
+
+        if (str_contains($currentFile, '/Domain/')) {
+            return $this->domainRule($node, $scope);
+        }
+
+        if (str_contains($currentFile, '/Application/')) {
+            return $this->applicationRule($node);
+        }
+
+        return [];
+    }
+
+    /**
+     * @param FullyQualified $node
+     *
+     * @return list<IdentifierRuleError>
+     */
+    protected function domainRule(Node $node, Scope $scope): array {
+        $usedClass = $node->toCodeString();
+
+        if (str_contains($usedClass, '\\Infrastructures\\') || str_contains($usedClass, '\\Infrastructure\\')) {
+            return [
+                RuleErrorBuilder::message('The Domain layer must not reference ' . $usedClass . ' from the Infrastructure layer.')
+                    ->identifier('ddd.domainAccessInfrastructureViolation')
+                    ->build(),
+            ];
+        }
+
+        if (str_contains($usedClass, '\\Applications\\') || str_contains($usedClass, '\\Application\\')) {
+            return [
+                RuleErrorBuilder::message('The Domain layer must not reference ' . $usedClass . ' from the Application layer.')
+                    ->identifier('ddd.domainAccessApplicationViolation')
+                    ->build(),
+            ];
+        }
+
+        $currentFile = $scope->getFile();
+        if (str_contains($currentFile, '/Models/') || str_contains($currentFile, '/Model/')) {
+            if (str_contains($usedClass, '\\Repositories\\') || str_contains($usedClass, '\\Repository\\')) {
+                return [
+                    RuleErrorBuilder::message('The Domain Model layer must not reference ' . $usedClass . ' from the Domain Repository layer.')
+                        ->identifier('ddd.domainModelAccessDomainRepositoryViolation')
+                        ->build(),
+                ];
+            }
+
+            if (str_contains($usedClass, '\\Services\\') || str_contains($usedClass, '\\Service\\')) {
+                return [
+                    RuleErrorBuilder::message('The Domain Model layer must not reference ' . $usedClass . ' from the Domain Service layer.')
+                        ->identifier('ddd.domainModelAccessDomainServiceViolation')
+                        ->build(),
+                ];
+            }
+        }
+        if (str_contains($currentFile, '/Repositories/') || str_contains($currentFile, '/Repository/')) {
+            if (str_contains($usedClass, '\\Repositories\\') || str_contains($usedClass, '\\Repository\\')) {
+                return [
+                    RuleErrorBuilder::message('The Domain Reposity layer must not reference ' . $usedClass . ' from the Domain Repository layer.')
+                        ->identifier('ddd.domainRepositoryAccessDomainRepositoryViolation')
+                        ->build(),
+                ];
+            }
+            if (str_contains($usedClass, '\\Services\\') || str_contains($usedClass, '\\Service\\')) {
+                return [
+                    RuleErrorBuilder::message('The Domain Reposity layer must not reference ' . $usedClass . ' from the Domain Service layer.')
+                        ->identifier('ddd.domainRepositoryAccessDomainServiceViolation')
+                        ->build(),
+                ];
+            }
+        }
+        if (str_contains($currentFile, '/Services/') || str_contains($currentFile, '/Service/')) {
+            if (str_contains($usedClass, '\\Repositories\\') || str_contains($usedClass, '\\Repository\\')) {
+                return [
+                    RuleErrorBuilder::message('The Domain Service layer must not reference ' . $usedClass . ' from the Domain Repository layer.')
+                        ->identifier('ddd.domainServiceAccessDomainRepositoryViolation')
+                        ->build(),
+                ];
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param FullyQualified $node
+     *
+     * @return list<IdentifierRuleError>
+     */
+    protected function applicationRule(Node $node): array {
+        $usedClass = $node->toCodeString();
+        if (str_contains($usedClass, '\\Infrastructures\\') || str_contains($usedClass, '\\Infrastructure\\')) {
+            return [
+                RuleErrorBuilder::message('The Application layer must not reference ' . $usedClass . ' from the Infrastructure layer.')
+                    ->identifier('ddd.applicationAccessInfrastructure')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/tests/DomainDrivenDesignRuleTest.php
+++ b/tests/DomainDrivenDesignRuleTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+use Hiper\PHPStan\Rules\DomainDrivenDesignRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * @phpstan-type FixturePaths string[]
+ * @phpstan-type ExpectedError array{0: string, 1: int, 2?: string|null}
+ * @phpstan-type ExpectedErrors list<ExpectedError>
+ * @phpstan-type Fixture array{0: FixturePaths, 1: ExpectedErrors}
+ * @phpstan-type Fixtures Fixture[]
+ *
+ * @extends RuleTestCase<DomainDrivenDesignRule>
+ */
+class DomainDrivenDesignRuleTest extends RuleTestCase {
+    protected function getRule(): Rule {
+        return new DomainDrivenDesignRule();
+    }
+
+    /** @return Fixtures */
+    public static function fixtureProvider(): array {
+        return [
+            [[__DIR__ . '/test-fixtures/Application/Service/ApplicationClassThatAccessDomain.php'], []],
+            [[__DIR__ . '/test-fixtures/Application/Service/ApplicationClassThatAccessRepository.php'], []],
+            [[__DIR__ . '/test-fixtures/Application/Service/ApplicationClassThatAccessService.php'], []],
+            [[__DIR__ . '/test-fixtures/Application/Service/ApplicationClassThatAccessApplication.php'], []],
+            [[__DIR__ . '/test-fixtures/Application/Service/ApplicationClassThatAccessInfrastructure.php'], [['The Application layer must not reference \\Test\\Infrastructure\\Infrastructure from the Infrastructure layer.', 8]]],
+            [[__DIR__ . '/test-fixtures/Domain/Models/DomainClassThatAccessDomain.php'], []],
+            [[__DIR__ . '/test-fixtures/Domain/Models/DomainClassThatAccessApplication.php'], [['The Domain layer must not reference \\Test\\Application\\Service\\ApplicationClassThatAccessDomain from the Application layer.', 8]]],
+            [[__DIR__ . '/test-fixtures/Domain/Models/DomainClassThatAccessService.php'], [['The Domain Model layer must not reference \\Test\\Domain\\Service\\ServiceClassThatAccessDomain from the Domain Service layer.', 8]]],
+            [[__DIR__ . '/test-fixtures/Domain/Models/DomainClassThatAccessRepository.php'], [['The Domain Model layer must not reference \\Test\\Domain\\Repositories\\RepositoryClassThatAccessDomain from the Domain Repository layer.', 8]]],
+            [[__DIR__ . '/test-fixtures/Domain/Models/DomainClassThatAccessInfrastructure.php'], [['The Domain layer must not reference \\Test\\Infrastructure\\Infrastructure from the Infrastructure layer.', 8]]],
+            [[__DIR__ . '/test-fixtures/Domain/Repositories/RepositoryClassThatAccessDomain.php'], []],
+            [[__DIR__ . '/test-fixtures/Domain/Repositories/RepositoryClassThatAccessRepository.php'], [['The Domain Reposity layer must not reference \\Test\\Domain\\Repositories\\RepositoryClassThatAccessDomain from the Domain Repository layer.', 6]]],
+            [[__DIR__ . '/test-fixtures/Domain/Repositories/RepositoryClassThatAccessService.php'], [['The Domain Reposity layer must not reference \\Test\\Domain\\Service\\ServiceClassThatAccessDomain from the Domain Service layer.', 8]]],
+            [[__DIR__ . '/test-fixtures/Domain/Repositories/RepositoryClassThatAccessApplication.php'], [['The Domain layer must not reference \\Test\\Application\\Service\\ApplicationClassThatAccessDomain from the Application layer.', 8]]],
+            [[__DIR__ . '/test-fixtures/Domain/Repositories/RepositoryClassThatAccessInfrastructure.php'], [['The Domain layer must not reference \\Test\\Infrastructure\\Infrastructure from the Infrastructure layer.', 8]]],
+            [[__DIR__ . '/test-fixtures/Domain/Service/ServiceClassThatAccessDomain.php'], []],
+            [[__DIR__ . '/test-fixtures/Domain/Service/ServiceClassThatAccessRepository.php'], [['The Domain Service layer must not reference \\Test\Domain\Repositories\RepositoryClassThatAccessDomain from the Domain Repository layer.', 8]]],
+            [[__DIR__ . '/test-fixtures/Domain/Service/ServiceClassThatAccessService.php'], []],
+            [[__DIR__ . '/test-fixtures/Domain/Service/ServiceClassThatAccessApplication.php'], [['The Domain layer must not reference \\Test\\Application\Service\\ApplicationClassThatAccessDomain from the Application layer.', 8]]],
+            [[__DIR__ . '/test-fixtures/Domain/Service/ServiceClassThatAccessInfrastructure.php'], [['The Domain layer must not reference \\Test\\Infrastructure\\Infrastructure from the Infrastructure layer.', 8]]],
+        ];
+    }
+
+    /**
+     * @param FixturePaths $paths_to_fixture
+     * @param ExpectedErrors $expected_errors
+     */
+    #[DataProvider('fixtureProvider')]
+    public function testDomainDrivenDesignRules(array $paths_to_fixture, array $expected_errors): void {
+        $this->analyse($paths_to_fixture, $expected_errors);
+    }
+}

--- a/tests/test-fixtures/Application/Service/ApplicationClassThatAccessApplication.php
+++ b/tests/test-fixtures/Application/Service/ApplicationClassThatAccessApplication.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Test\Application\Service;
+
+class ApplicationClassThatAccessApplication {
+    public function __construct(ApplicationClassThatAccessApplication $_) {
+
+    }
+}

--- a/tests/test-fixtures/Application/Service/ApplicationClassThatAccessDomain.php
+++ b/tests/test-fixtures/Application/Service/ApplicationClassThatAccessDomain.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Test\Application\Service;
+
+class ApplicationClassThatAccessDomain {
+    public function __construct(ApplicationClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Application/Service/ApplicationClassThatAccessInfrastructure.php
+++ b/tests/test-fixtures/Application/Service/ApplicationClassThatAccessInfrastructure.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Application\Service;
+
+use Test\Infrastructure\Infrastructure;
+
+class ApplicationClassThatAccessInfrastructure {
+    public function __construct(Infrastructure $_) {
+
+    }
+}

--- a/tests/test-fixtures/Application/Service/ApplicationClassThatAccessRepository.php
+++ b/tests/test-fixtures/Application/Service/ApplicationClassThatAccessRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Application\Service;
+
+use Test\Domain\Repositories\ServiceClasssThatAccessDomain;
+
+class ApplicationClassThatAccessRepository {
+    public function __construct(ServiceClasssThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Application/Service/ApplicationClassThatAccessService.php
+++ b/tests/test-fixtures/Application/Service/ApplicationClassThatAccessService.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Application\Service;
+
+use Test\Domain\Service\ServiceClassThatAccessDomain;
+
+class ApplicationClassThatAccessService {
+    public function __construct(ServiceClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Models/DomainClassThatAccessApplication.php
+++ b/tests/test-fixtures/Domain/Models/DomainClassThatAccessApplication.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Domain\Models;
+
+use Test\Application\Service\ApplicationClassThatAccessDomain;
+
+class DomainClassThatAccessApplication {
+    public function __construct(ApplicationClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Models/DomainClassThatAccessDomain.php
+++ b/tests/test-fixtures/Domain/Models/DomainClassThatAccessDomain.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Test\Domain\Models;
+
+class DomainClassThatAccessDomain {
+    public function __construct(DomainClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Models/DomainClassThatAccessInfrastructure.php
+++ b/tests/test-fixtures/Domain/Models/DomainClassThatAccessInfrastructure.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Domain\Models;
+
+use Test\Infrastructure\Infrastructure;
+
+class DomainClassThatAccessInfrastructure {
+    public function __construct(Infrastructure $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Models/DomainClassThatAccessRepository.php
+++ b/tests/test-fixtures/Domain/Models/DomainClassThatAccessRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Domain\Models;
+
+use Test\Domain\Repositories\RepositoryClassThatAccessDomain;
+
+class DomainClassThatAccessRepository {
+    public function __construct(RepositoryClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Models/DomainClassThatAccessService.php
+++ b/tests/test-fixtures/Domain/Models/DomainClassThatAccessService.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Domain\Models;
+
+use Test\Domain\Service\ServiceClassThatAccessDomain;
+
+class DomainClassThatAccessService {
+    public function __construct(ServiceClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Repositories/RepositoryClassThatAccessApplication.php
+++ b/tests/test-fixtures/Domain/Repositories/RepositoryClassThatAccessApplication.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Domain\Repositories;
+
+use Test\Application\Service\ApplicationClassThatAccessDomain;
+
+class RepositoryClassThatAccessApplication {
+    public function __construct(ApplicationClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Repositories/RepositoryClassThatAccessDomain.php
+++ b/tests/test-fixtures/Domain/Repositories/RepositoryClassThatAccessDomain.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Domain\Repositories;
+
+use Test\Domain\Models\DomainClassThatAccessDomain;
+
+class RepositoryClassThatAccessDomain {
+    public function __construct(DomainClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Repositories/RepositoryClassThatAccessInfrastructure.php
+++ b/tests/test-fixtures/Domain/Repositories/RepositoryClassThatAccessInfrastructure.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Domain\Repositories;
+
+use Test\Infrastructure\Infrastructure;
+
+class RepositoryClassThatAccessInfrastructure {
+    public function __construct(Infrastructure $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Repositories/RepositoryClassThatAccessRepository.php
+++ b/tests/test-fixtures/Domain/Repositories/RepositoryClassThatAccessRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Test\Domain\Repositories;
+
+class RepositoryClassThatAccessRepository {
+    public function __construct(RepositoryClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Repositories/RepositoryClassThatAccessService.php
+++ b/tests/test-fixtures/Domain/Repositories/RepositoryClassThatAccessService.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Domain\Repositories;
+
+use Test\Domain\Service\ServiceClassThatAccessDomain;
+
+class RepositoryClassThatAccessService {
+    public function __construct(ServiceClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Service/ServiceClassThatAccessApplication.php
+++ b/tests/test-fixtures/Domain/Service/ServiceClassThatAccessApplication.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Domain\Service;
+
+use Test\Application\Service\ApplicationClassThatAccessDomain;
+
+class ServiceClassThatAccessApplication {
+    public function __construct(ApplicationClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Service/ServiceClassThatAccessDomain.php
+++ b/tests/test-fixtures/Domain/Service/ServiceClassThatAccessDomain.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Domain\Service;
+
+use Test\Domain\Models\DomainClassThatAccessDomain;
+
+class ServiceClassThatAccessDomain {
+    public function __construct(DomainClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Service/ServiceClassThatAccessInfrastructure.php
+++ b/tests/test-fixtures/Domain/Service/ServiceClassThatAccessInfrastructure.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Domain\Service;
+
+use Test\Infrastructure\Infrastructure;
+
+class ServiceClassThatAccessInfrastructure {
+    public function __construct(Infrastructure $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Service/ServiceClassThatAccessRepository.php
+++ b/tests/test-fixtures/Domain/Service/ServiceClassThatAccessRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\Domain\Service;
+
+use Test\Domain\Repositories\RepositoryClassThatAccessDomain;
+
+class ServiceClassThatAccessRepository {
+    public function __construct(RepositoryClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Domain/Service/ServiceClassThatAccessService.php
+++ b/tests/test-fixtures/Domain/Service/ServiceClassThatAccessService.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Test\Domain\Service;
+
+class ServiceClassThatAccessService {
+    public function __construct(ServiceClassThatAccessDomain $_) {
+
+    }
+}

--- a/tests/test-fixtures/Infrastructure/Infrastructure.php
+++ b/tests/test-fixtures/Infrastructure/Infrastructure.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Test\Infrastructure;
+
+class Infrastructure {
+
+}


### PR DESCRIPTION
Verify access rules from Hexagonal architecture, that dictates only outer layers may depend on inner layers

Infrastructure -> Application Service -> Domain Service -> Domain Repository -> Domain Entities -> Domain Value Objects

![image](https://github.com/user-attachments/assets/02cf97a0-5bb5-469c-8084-161e1d283291)
